### PR TITLE
fix: parameter name for list->tuple func

### DIFF
--- a/pattern_matching/exercises.ex
+++ b/pattern_matching/exercises.ex
@@ -72,7 +72,7 @@ defmodule Spirit.Exercises.PatternMatching do
       {"x", "y", "z"}
 
   """
-  def list_to_three_tuple(tuple) do
+  def list_to_three_tuple(list) do
   end
 
   @doc """


### PR DESCRIPTION
Fixed typo/incorrect parameter name for function on line 75.