### PR TITLE
Drop `Exercises` from module names

### DIFF
--- a/anonymous_functions/exercises.ex
+++ b/anonymous_functions/exercises.ex
@@ -1,4 +1,4 @@
-defmodule Spirit.Exercises.AnonymousFunctions do
+defmodule Spirit.AnonymousFunctions do
   @moduledoc """
   Exercises for "Anonymous functions"
   Guide Page: <https://hexdocs.pm/elixir/anonymous-functions.html>
@@ -17,7 +17,7 @@ defmodule Spirit.Exercises.AnonymousFunctions do
 
   ## Examples
 
-      iex> inc = Spirit.Exercises.AnonymousFunctions.create_incrementer(1)
+      iex> inc = Spirit.AnonymousFunctions.create_incrementer(1)
       iex> inc.(2)
       3
 
@@ -29,7 +29,7 @@ defmodule Spirit.Exercises.AnonymousFunctions do
   Returns an anonymous function that prepends `"[ERROR]"` to the given message
   string.
 
-      iex> logger = Spirit.Exercises.AnonymousFunctions.create_error_logger()
+      iex> logger = Spirit.AnonymousFunctions.create_error_logger()
       iex> logger.("invalid input")
       "[ERROR] invalid input"
 
@@ -41,7 +41,7 @@ defmodule Spirit.Exercises.AnonymousFunctions do
   Returns an anonymous function that prepends `"[SUCCESS]"` to the given
   message string.
 
-      iex> logger = Spirit.Exercises.AnonymousFunctions.create_success_logger()
+      iex> logger = Spirit.AnonymousFunctions.create_success_logger()
       iex> logger.("request sent")
       "[SUCCESS] request sent"
 
@@ -55,10 +55,10 @@ defmodule Spirit.Exercises.AnonymousFunctions do
 
   ### Examples
 
-      iex> Spirit.Exercises.AnonymousFunctions.log_result({:ok, "sent"})
+      iex> Spirit.AnonymousFunctions.log_result({:ok, "sent"})
       "[SUCCESS] sent"
 
-      iex> Spirit.Exercises.AnonymousFunctions.log_result({:error, "failed"})
+      iex> Spirit.AnonymousFunctions.log_result({:error, "failed"})
       "[ERROR] failed"
 
   """

--- a/anonymous_functions/exercises_test.exs
+++ b/anonymous_functions/exercises_test.exs
@@ -1,9 +1,9 @@
-defmodule Spirit.Exercises.AnonymousFunctionsTest do
+defmodule Spirit.AnonymousFunctionsTest do
   use ExUnit.Case
 
-  doctest Spirit.Exercises.AnonymousFunctions
+  doctest Spirit.AnonymousFunctions
 
-  alias Spirit.Exercises.AnonymousFunctions
+  alias Spirit.AnonymousFunctions
 
   describe "Anonymous functions Tests" do
     test "create_incrementer/1" do

--- a/basic_types/exercises.ex
+++ b/basic_types/exercises.ex
@@ -1,4 +1,4 @@
-defmodule Spirit.Exercises.BasicTypes do
+defmodule Spirit.BasicTypes do
   @moduledoc """
   Exercises for "Basic Types"
   Guide Page: <https://hexdocs.pm/elixir/basic-types.html>
@@ -23,10 +23,10 @@ defmodule Spirit.Exercises.BasicTypes do
 
   ## Examples
 
-      iex> Spirit.Exercises.BasicTypes.format_percentage(0.5)
+      iex> Spirit.BasicTypes.format_percentage(0.5)
       iex> "50%"
 
-      iex> Spirit.Exercises.BasicTypes.format_percentage(-1.236)
+      iex> Spirit.BasicTypes.format_percentage(-1.236)
       iex> "-124%"
 
   """
@@ -38,13 +38,13 @@ defmodule Spirit.Exercises.BasicTypes do
 
   ## Examples
 
-      iex> Spirit.Exercises.BasicTypes.opposites?(true, false)
+      iex> Spirit.BasicTypes.opposites?(true, false)
       true
 
-      iex> Spirit.Exercises.BasicTypes.opposites?(nil, [])
+      iex> Spirit.BasicTypes.opposites?(nil, [])
       true
 
-      iex> Spirit.Exercises.BasicTypes.opposites?(1, "hi")
+      iex> Spirit.BasicTypes.opposites?(1, "hi")
       false
 
   """
@@ -58,7 +58,7 @@ defmodule Spirit.Exercises.BasicTypes do
 
   ## Examples
 
-      iex> Spirit.Exercises.BasicTypes.boolean_opposites?(true, false)
+      iex> Spirit.BasicTypes.boolean_opposites?(true, false)
       true
 
   """
@@ -69,7 +69,7 @@ defmodule Spirit.Exercises.BasicTypes do
   Converts the given string to uppercase and appends an exclamation mark at the
   end.
 
-      iex> Spirit.Exercises.BasicTypes.shout("yes")
+      iex> Spirit.BasicTypes.shout("yes")
       "YES!"
 
   """

--- a/basic_types/exercises_test.exs
+++ b/basic_types/exercises_test.exs
@@ -1,10 +1,10 @@
-defmodule Spirit.Exercises.BasicTypesTest do
+defmodule Spirit.BasicTypesTest do
   use ExUnit.Case
 
-  doctest Spirit.Exercises.BasicTypes
+  doctest Spirit.BasicTypes
 
   test "simple_tuple/0" do
-    result = Spirit.Exercises.BasicTypes.simple_tuple()
+    result = Spirit.BasicTypes.simple_tuple()
 
     assert {atom, list} = result
     assert atom == :ok
@@ -12,34 +12,34 @@ defmodule Spirit.Exercises.BasicTypesTest do
   end
 
   test "format_percentage/1" do
-    result = Spirit.Exercises.BasicTypes.format_percentage(0.5)
+    result = Spirit.BasicTypes.format_percentage(0.5)
 
     assert result == "50%"
 
-    result = Spirit.Exercises.BasicTypes.format_percentage(-1.236)
+    result = Spirit.BasicTypes.format_percentage(-1.236)
 
     assert result == "-124%"
   end
 
   test "opposites?/2" do
-    assert Spirit.Exercises.BasicTypes.opposites?(true, false) == true
-    assert Spirit.Exercises.BasicTypes.opposites?(nil, []) == true
-    assert Spirit.Exercises.BasicTypes.opposites?(1, "hi") == false
+    assert Spirit.BasicTypes.opposites?(true, false) == true
+    assert Spirit.BasicTypes.opposites?(nil, []) == true
+    assert Spirit.BasicTypes.opposites?(1, "hi") == false
   end
 
   test "boolean_opposites?/2" do
-    assert Spirit.Exercises.BasicTypes.boolean_opposites?(true, false) == true
+    assert Spirit.BasicTypes.boolean_opposites?(true, false) == true
 
     assert_raise BadBooleanError, fn ->
-      Spirit.Exercises.BasicTypes.boolean_opposites?(nil, [])
+      Spirit.BasicTypes.boolean_opposites?(nil, [])
     end
 
     assert_raise BadBooleanError, fn ->
-      Spirit.Exercises.BasicTypes.boolean_opposites?(1, "hi")
+      Spirit.BasicTypes.boolean_opposites?(1, "hi")
     end
   end
 
   test "shout/1" do
-    assert Spirit.Exercises.BasicTypes.shout("hi") == "HI!"
+    assert Spirit.BasicTypes.shout("hi") == "HI!"
   end
 end

--- a/binaries_strings_and_charlists/exercises.ex
+++ b/binaries_strings_and_charlists/exercises.ex
@@ -1,4 +1,4 @@
-defmodule Spirit.Exercises.BinariesStringsAndCharlists do
+defmodule Spirit.BinariesStringsAndCharlists do
   @moduledoc """
   Exercises for "Binaries, strings, and charlists"
   Guide Page: <https://hexdocs.pm/elixir/binaries-strings-and-charlists.html>
@@ -15,11 +15,11 @@ defmodule Spirit.Exercises.BinariesStringsAndCharlists do
   ## Examples
 
       iex> s = "ok"
-      iex> Spirit.Exercises.BinariesStringsAndCharlists.first_char(s)
+      iex> Spirit.BinariesStringsAndCharlists.first_char(s)
       iex> "o"
 
       iex> s = ""
-      iex> Spirit.Exercises.BinariesStringsAndCharlists.first_char(s)
+      iex> Spirit.BinariesStringsAndCharlists.first_char(s)
       iex> nil
 
   """
@@ -35,7 +35,7 @@ defmodule Spirit.Exercises.BinariesStringsAndCharlists do
   ## Examples
 
       iex> s = "hello 👋"
-      iex> Spirit.Exercises.BinariesStringsAndCharlists.describe_string(s)
+      iex> Spirit.BinariesStringsAndCharlists.describe_string(s)
       %{n_chars: 7, byte_size: 10, first_char: "h"}
 
   """
@@ -65,11 +65,11 @@ defmodule Spirit.Exercises.BinariesStringsAndCharlists do
   ## Examples 
 
       iex> b = <<1::1, 0::1>>
-      iex> Spirit.Exercises.BinariesStringsAndCharlists.second_bit_is_one?(b)
+      iex> Spirit.BinariesStringsAndCharlists.second_bit_is_one?(b)
       iex> false
 
       iex> b = "a"
-      iex> Spirit.Exercises.BinariesStringsAndCharlists.second_bit_is_one?(b)
+      iex> Spirit.BinariesStringsAndCharlists.second_bit_is_one?(b)
       iex> true
 
   """
@@ -89,11 +89,11 @@ defmodule Spirit.Exercises.BinariesStringsAndCharlists do
   ## Examples
 
       iex> c = ~c"hi"
-      iex> Spirit.Exercises.BinariesStringsAndCharlists.switch_string_and_charlist(c)
+      iex> Spirit.BinariesStringsAndCharlists.switch_string_and_charlist(c)
       iex> "hi"
 
       iex> s = "hi"
-      iex> Spirit.Exercises.BinariesStringsAndCharlists.switch_string_and_charlist(s)
+      iex> Spirit.BinariesStringsAndCharlists.switch_string_and_charlist(s)
       iex> ~c"hi"
 
   """

--- a/binaries_strings_and_charlists/exercises_test.exs
+++ b/binaries_strings_and_charlists/exercises_test.exs
@@ -1,9 +1,9 @@
-defmodule Spirit.Exercises.BinariesStringsAndCharlistsTest do
+defmodule Spirit.BinariesStringsAndCharlistsTest do
   use ExUnit.Case
 
-  doctest Spirit.Exercises.BinariesStringsAndCharlists
+  doctest Spirit.BinariesStringsAndCharlists
 
-  alias Spirit.Exercises.BinariesStringsAndCharlists
+  alias Spirit.BinariesStringsAndCharlists
 
   describe "Binaries, strings, and charlists Tests" do
     test "first_char/1" do

--- a/case_cond_and_if/exercises.ex
+++ b/case_cond_and_if/exercises.ex
@@ -1,4 +1,4 @@
-defmodule Spirit.Exercises.CaseCondAndIf do
+defmodule Spirit.CaseCondAndIf do
   @moduledoc """
   Exercises for "case, cond, and if"
   Guide Page: <https://hexdocs.pm/elixir/case-cond-and-if.html>
@@ -40,11 +40,11 @@ defmodule Spirit.Exercises.CaseCondAndIf do
   ## Examples
 
       iex> valid_header = "Bearer Ug+H2dqRHpE"
-      iex> Spirit.Exercises.CaseCondAndIf.extract_bearer_token(valid_header)
+      iex> Spirit.CaseCondAndIf.extract_bearer_token(valid_header)
       {:ok, "Ug+H2dqRHpE"}
 
       iex> invalid_header = "oops"
-      iex> Spirit.Exercises.CaseCondAndIf.extract_bearer_token(invalid_header)
+      iex> Spirit.CaseCondAndIf.extract_bearer_token(invalid_header)
       {:error, :invalid_header}
 
   """
@@ -58,10 +58,10 @@ defmodule Spirit.Exercises.CaseCondAndIf do
 
   ## Examples
 
-      iex> Spirit.Exercises.CaseCondAndIf.odd_or_even(42)
+      iex> Spirit.CaseCondAndIf.odd_or_even(42)
       :even
 
-      iex> Spirit.Exercises.CaseCondAndIf.odd_or_even(333)
+      iex> Spirit.CaseCondAndIf.odd_or_even(333)
       :odd
 
   """
@@ -79,16 +79,16 @@ defmodule Spirit.Exercises.CaseCondAndIf do
 
   ## Examples
 
-    iex> Spirit.Exercises.CaseCondAndIf.fizz_buzz(12)
+    iex> Spirit.CaseCondAndIf.fizz_buzz(12)
     :fizz
 
-    iex> Spirit.Exercises.CaseCondAndIf.fizz_buzz(5)
+    iex> Spirit.CaseCondAndIf.fizz_buzz(5)
     :buzz
 
-    iex> Spirit.Exercises.CaseCondAndIf.fizz_buzz(15)
+    iex> Spirit.CaseCondAndIf.fizz_buzz(15)
     :fizzbuzz
 
-    iex> Spirit.Exercises.CaseCondAndIf.fizz_buzz(16)
+    iex> Spirit.CaseCondAndIf.fizz_buzz(16)
     16
 
   """

--- a/case_cond_and_if/exercises_test.exs
+++ b/case_cond_and_if/exercises_test.exs
@@ -1,9 +1,9 @@
-defmodule Spirit.Exercises.CaseCondAndIfTest do
+defmodule Spirit.CaseCondAndIfTest do
   use ExUnit.Case
 
-  doctest Spirit.Exercises.CaseCondAndIf
+  doctest Spirit.CaseCondAndIf
 
-  alias Spirit.Exercises.CaseCondAndIf
+  alias Spirit.CaseCondAndIf
 
   describe "case, cond, and if Tests" do
     test "check_result/1" do

--- a/lists_and_tuples/exercises.ex
+++ b/lists_and_tuples/exercises.ex
@@ -1,4 +1,4 @@
-defmodule Spirit.Exercises.ListsAndTuples do
+defmodule Spirit.ListsAndTuples do
   @moduledoc """
   Exercises for "Lists and Tuples"
   Guide Page: <https://hexdocs.pm/elixir/lists-and-tuples.html>
@@ -14,7 +14,7 @@ defmodule Spirit.Exercises.ListsAndTuples do
 
   ## Examples
 
-      iex> list = Spirit.Exercises.ListsAndTuples.three_item_list()
+      iex> list = Spirit.ListsAndTuples.three_item_list()
       [1, 2, 3]
       iex> length(list)
       3
@@ -30,7 +30,7 @@ defmodule Spirit.Exercises.ListsAndTuples do
 
       iex> list_a = [1, 2, 3]
       iex> list_b = [true, false, nil]
-      iex> Spirit.Exercises.ListsAndTuples.add_two_lists(list_a, list_b)
+      iex> Spirit.ListsAndTuples.add_two_lists(list_a, list_b)
       [1, 2, 3, true, false, nil]
   """
   def add_two_lists(list_a, list_b) do
@@ -43,7 +43,7 @@ defmodule Spirit.Exercises.ListsAndTuples do
 
       iex> list_a = [1, true, 2, false, 3]
       iex> list_b = [true, false]
-      iex> Spirit.Exercises.ListsAndTuples.subtract_two_lists(list_a, list_b)
+      iex> Spirit.ListsAndTuples.subtract_two_lists(list_a, list_b)
       [1, 2, 3]
   """
   def subtract_two_lists(list_a, list_b) do
@@ -54,7 +54,7 @@ defmodule Spirit.Exercises.ListsAndTuples do
 
   ## Examples
 
-      iex> Spirit.Exercises.ListsAndTuples.return_list_head([1, 2, 3])
+      iex> Spirit.ListsAndTuples.return_list_head([1, 2, 3])
       1
   """
   def return_list_head(list) do
@@ -65,7 +65,7 @@ defmodule Spirit.Exercises.ListsAndTuples do
 
   ## Examples
 
-      iex> Spirit.Exercises.ListsAndTuples.return_list_tail([1, 2, 3])
+      iex> Spirit.ListsAndTuples.return_list_tail([1, 2, 3])
       [2, 3]
   """
   def return_list_tail(list) do
@@ -78,7 +78,7 @@ defmodule Spirit.Exercises.ListsAndTuples do
 
   ## Examples
 
-      iex> Spirit.Exercises.ListsAndTuples.return_two_tuple(:hello, "world")
+      iex> Spirit.ListsAndTuples.return_two_tuple(:hello, "world")
       {:hello, "world"}
   """
   def return_two_tuple(first_elem, second_elem) do
@@ -89,7 +89,7 @@ defmodule Spirit.Exercises.ListsAndTuples do
 
   ## Examples
 
-      iex> Spirit.Exercises.ListsAndTuples.return_tuple_size({:a, :b, :c})
+      iex> Spirit.ListsAndTuples.return_tuple_size({:a, :b, :c})
       3
   """
   def return_tuple_size(tuple) do
@@ -100,7 +100,7 @@ defmodule Spirit.Exercises.ListsAndTuples do
 
   ## Examples
 
-      iex> Spirit.Exercises.ListsAndTuples.return_list_length([1, 2, 3])
+      iex> Spirit.ListsAndTuples.return_list_length([1, 2, 3])
       3
   """
   def return_list_length(list) do

--- a/lists_and_tuples/exercises_test.exs
+++ b/lists_and_tuples/exercises_test.exs
@@ -1,9 +1,9 @@
-defmodule Spirit.Exercises.ListsAndTuplesTests do
+defmodule Spirit.ListsAndTuplesTests do
   use ExUnit.Case
 
-  doctest Spirit.Exercises.ListsAndTuples
+  doctest Spirit.ListsAndTuples
 
-  alias Spirit.Exercises.ListsAndTuples
+  alias Spirit.ListsAndTuples
 
   describe "Lists and Tuples Tests" do
     test "three_item_list/0" do

--- a/pattern_matching/exercises.ex
+++ b/pattern_matching/exercises.ex
@@ -1,4 +1,4 @@
-defmodule Spirit.Exercises.PatternMatching do
+defmodule Spirit.PatternMatching do
   @moduledoc """
   Exercises for "Pattern Matching"
   Guide Page: <https://hexdocs.pm/elixir/pattern-matching.html>
@@ -19,7 +19,7 @@ defmodule Spirit.Exercises.PatternMatching do
 
   ## Examples
 
-      iex> Spirit.Exercises.PatternMatching.match_with_42(42)
+      iex> Spirit.PatternMatching.match_with_42(42)
       42
 
   """
@@ -29,7 +29,7 @@ defmodule Spirit.Exercises.PatternMatching do
   @doc """
   Uses pattern matching to ensure two values are equal to each other.
 
-      iex> Spirit.Exercises.PatternMatching.match_values(10, 10)
+      iex> Spirit.PatternMatching.match_values(10, 10)
       10
 
   """
@@ -42,7 +42,7 @@ defmodule Spirit.Exercises.PatternMatching do
   ## Examples
 
       iex> t = {:ok, "hello"}
-      iex> Spirit.Exercises.PatternMatching.first_of_two_tuple(t)
+      iex> Spirit.PatternMatching.first_of_two_tuple(t)
       :ok
 
   """
@@ -55,7 +55,7 @@ defmodule Spirit.Exercises.PatternMatching do
   ## Examples
 
       iex> t = {:ok, "hello"}
-      iex> Spirit.Exercises.PatternMatching.get_result_value(t)
+      iex> Spirit.PatternMatching.get_result_value(t)
       "hello"
 
   """
@@ -68,7 +68,7 @@ defmodule Spirit.Exercises.PatternMatching do
   ## Examples
 
       iex> l = ["x", "y", "z"]
-      iex> Spirit.Exercises.PatternMatching.list_to_three_tuple(l)
+      iex> Spirit.PatternMatching.list_to_three_tuple(l)
       {"x", "y", "z"}
 
   """
@@ -81,7 +81,7 @@ defmodule Spirit.Exercises.PatternMatching do
   ## Examples
 
       iex> l = ["x", "y", "z"]
-      iex> Spirit.Exercises.PatternMatching.head_and_tail(l)
+      iex> Spirit.PatternMatching.head_and_tail(l)
       {"x", ["y", "z"]}
 
   """

--- a/pattern_matching/exercises_test.exs
+++ b/pattern_matching/exercises_test.exs
@@ -1,9 +1,9 @@
-defmodule Spirit.Exercises.PatternMatchingTest do
+defmodule Spirit.PatternMatchingTest do
   use ExUnit.Case
 
-  doctest Spirit.Exercises.PatternMatching
+  doctest Spirit.PatternMatching
 
-  alias Spirit.Exercises.PatternMatching
+  alias Spirit.PatternMatching
 
   describe "Lists and Tuples Tests" do
     test "match_with_42/1" do


### PR DESCRIPTION
See also https://github.com/PracticeCraft/spirit/pull/18