### PR TITLE
Add extra modules to module_list.txt

### DIFF
--- a/module_list.txt
+++ b/module_list.txt
@@ -4,3 +4,6 @@ pattern_matching
 case_cond_and_if
 anonymous_functions
 binaries_strings_and_charlists
+keyword_lists_and_maps
+modules_and_functions
+recursion


### PR DESCRIPTION
This is to test how spirit.gen behaves if there are more names than modules to fetch.