### PR TITLE
Add exercises for "recursion"

### DIFF
--- a/recursion/exercises.ex
+++ b/recursion/exercises.ex
@@ -1,0 +1,153 @@
+defmodule Spirit.Recursion do
+  @moduledoc """
+  Exercises for "Recursion"
+  Guide Page: <https://hexdocs.pm/elixir/recursion.html>
+
+  These exercises will get you used to using recursion as a replacement for loop constructs.
+
+  Tip: 
+  When building lists in Elixir, prepending items has a time complexity of O(1) while appending
+  has a time complexity of O(n). While its better to build lists by prepending, you'll notice
+  your list will be in the reverse order you want. You might be tempted to use the appending method 
+  in this case, but its still more efficent to build your list by prepending then reversing it when
+  complete. This is a consequence of singly-linked lists in a language with immutable data structres.
+  """
+
+  @doc """
+  Returns the last element in a list.
+
+  ## Examples
+
+      iex> Spirit.Recursion.last([1, 2, 3, 4, 5, 6])
+      6
+      
+      iex> Spirit.Recursion.last([])
+      nil
+  """
+  def last(list) do
+  end
+
+  @doc """
+  Returns true if the list of integers is sorted in ascending order.
+
+  ## Examples
+
+      iex> Spirit.Recursion.sorted?([1, 2, 3, 4, 5])
+      true
+
+      iex> Spirit.Recursion.sorted?([3, 2, 1])
+      false
+      
+      iex> Spirit.Recursion.sorted?([])
+      true
+  """
+  def sorted?(list) do
+  end
+
+  @doc """
+  Returns the average of a list of numbers.
+
+  ## Examples
+
+      iex> Spirit.Recursion.average([1, 2, 3, 4, 5], 0, 0)
+      3.0
+      
+      iex> Spirit.Recursion.average([1], 0, 0)
+      1.0
+      
+      iex> Spirit.Recursion.average([], 0, 0)
+      0
+  """
+  def average(list, acc, count) do
+  end
+
+  @doc """
+  Returns a reversed list.
+
+  ## Examples
+      
+      iex> Spirit.Recursion.reverse([1, 2, 3, 4, 5], [])
+      [5, 4, 3, 2, 1]
+
+      iex> Spirit.Recursion.reverse([], [])
+      []
+  """
+  def reverse(list, acc) do
+  end
+
+  @doc """
+  Returns a list of integers where each integer is squared.
+
+  ## Examples
+      
+      iex> Spirit.Recursion.square_each([2, 4, 6], [])
+      [4, 16, 36]
+      
+      iex> Spirit.Recursion.square_each([], [])
+      []
+  """
+  def square_each(list, acc) do
+  end
+
+  @doc """
+  Returns a list with each element set according to "fizzbuzz" rules.
+
+  Rules
+  For each element in the original list of integers
+  - If divisible by 15 -> :fizzbuzz
+  - Else if divisible by 3 -> :fizz
+  - Else if divisible by 5 -> :buzz
+  - Default -> the original integer
+
+  ## Examples
+      
+      iex> Spirit.Recursion.fizzbuzz([1, 2, 3, 4, 5], [])
+      [1, 2, :fizz, 4, :buzz]
+      
+      iex> Spirit.Recursion.fizzbuzz([], [])
+      []
+  """
+  def fizzbuzz(list, acc) do
+  end
+
+  @doc """
+  Returns a list of partial sums. 
+  For instance, given [a, b, c], returns [a, a + b, a + b + c].
+
+  ## Examples
+
+      iex> Spirit.Recursion.partial_sums([1, 2, 3, 4], [], 0)
+      [1, 3, 6, 10]
+
+      iex> Spirit.Recursion.partial_sums([1], [], 0)
+      [1]
+
+      iex> Spirit.Recursion.partial_sums([], [], 0)
+      []
+  """
+  def partial_sums(list, acc, running_sum) do
+  end
+
+  @doc """
+  Merges 2 sorted lists into a single sorted list
+
+  ## Examples
+      
+      iex> Spirit.Recursion.merge([1, 3, 5], [2, 4, 6], [])
+      [1, 2, 3, 4, 5, 6]
+      
+      iex> Spirit.Recursion.merge([1, 3, 5], [2, 4, 6, 7], [])
+      [1, 2, 3, 4, 5, 6, 7]
+
+      iex> Spirit.Recursion.merge([1, 3, 5], [], [])
+      [1, 3, 5]
+
+      iex> Spirit.Recursion.merge([], [2, 4, 6], [])
+      [2, 4, 6]
+
+      iex> Spirit.Recursion.merge([], [], [])
+      []
+  """
+  def merge(list_1, list_2, acc) do
+  end
+end

--- a/recursion/exercises_test.exs
+++ b/recursion/exercises_test.exs
@@ -1,0 +1,52 @@
+defmodule Spirit.RecursionTest do
+  use ExUnit.Case
+
+  doctest Spirit.Recursion
+
+  alias Spirit.Recursion
+
+  describe "Recursion Tests" do
+    test "last/1" do
+      assert Recursion.last([1, 2, 3, 4, 5, 6, 7, 8, 9, 0]) == 0
+    end
+
+    test "sorted/1" do
+      assert Recursion.sorted?([1, 2, 3, 13, 4]) == false
+    end
+
+    test "average/3" do
+      assert Recursion.average([10, 11, 20, 35], 0, 0) == 19.0
+    end
+
+    test "reverse/2" do
+      assert Recursion.reverse([5, 4, 3, 2, 1, 0], []) == [0, 1, 2, 3, 4, 5]
+    end
+
+    test "square_each/2" do
+      assert Recursion.square_each([5, 10, 15, 20], []) == [25, 100, 225, 400]
+    end
+
+    test "fizzbuzz/2" do
+      assert Recursion.fizzbuzz([1, 2, 3, 4, 5, 6, 7, 8, 9, 15], []) == [
+               1,
+               2,
+               :fizz,
+               4,
+               :buzz,
+               :fizz,
+               7,
+               8,
+               :fizz,
+               :fizzbuzz
+             ]
+    end
+
+    test "partial_sums/3" do
+      assert Recursion.partial_sums([1, 5, 10, 20], [], 0) == [1, 6, 16, 36]
+    end
+
+    test "merge/3" do
+      assert Recursion.merge([1, 4, 10], [0, 4, 9, 11], []) == [0, 1, 4, 4, 9, 10, 11]
+    end
+  end
+end


### PR DESCRIPTION
This pull request adds a set of exercises designed to reinforce key concepts in recursion, specifically focusing on using reduce and map algorithms to work with lists. 

The exercises include:
    - last/1: Retrieves the last element of a list.
    - sorted?/1: Checks if a list is sorted in ascending order.
    - average/3: Calculates the average of a list of numbers.
    - reverse/2: Reverses a list using tail recursion. *
    - square_each/2: Squares each element of a list.
    - fizzbuzz/2: Transforms a list of integers using fizzbuzz rules.
    - partial_sums/3: Builds a list of partial sums.
    - merge/3: Merges two sorted lists into one sorted list.
   
   \* the reverse/2 exercise is intentionally ordered before any functions that output lists. This is done to encourage prepending + reversing.
   
Other things to note:
    - The chapter talks about reduce and map algorithms, so the exercises prioritize those.
    - The exercises focus on processing lists since that's more realistic.
    - The function signatures are designed to encourage tail-call recursion.
    - The module doc has a tip about efficient list building. Prepending + reversing is not intuitive for first time FP learners and needs to be explicitly pointed out.

Overall, these exercises provide a good foundation for using recursion in-lieu of loop constructs with elixir. 

Please review the changes and let me know if there are any suggestions for improvement or further clarifications needed.